### PR TITLE
[OPAL-000] Use Node 16 LTS to fix dependency issue with keytar package

### DIFF
--- a/Formula/opal-security.rb
+++ b/Formula/opal-security.rb
@@ -11,7 +11,7 @@ class OpalSecurity < Formula
     url :stable
   end
 
-  depends_on "node"
+  depends_on "node@16"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)


### PR DESCRIPTION
Error was:
```
5520 error npm verb stack Error: ENOENT: no such file or directory, open 'null/package.json'
5520 error npm verb cwd /usr/local/Cellar/opal-security/2.0.8/libexec/lib/node_modules/opal-security/node_modules/keytar
5520 error npm verb Darwin 20.6.0
5520 error npm verb argv "/usr/local/Cellar/node/17.2.0/bin/node" "/usr/local/opt/node/libexec/bin/npm" "run" "build"
5520 error npm verb node v17.2.0
5520 error npm verb npm  v8.1.4
5520 error npm ERR! code ENOENT
5520 error npm ERR! syscall open
5520 error npm ERR! path null/package.json
5520 error npm ERR! errno -2
5520 error npm ERR! enoent ENOENT: no such file or directory, open 'null/package.json'
5520 error npm ERR! enoent This is related to npm not being able to find a file.
5520 error npm ERR! enoent
```